### PR TITLE
Switch from Cobertura to JaCoCo for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,5 @@ jdk:
   - oraclejdk8
   - openjdk8
 
-script:
-  - "mvn cobertura:cobertura"
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -130,18 +130,25 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
       </plugin>
-      <!-- codecov coverage integration -->
+      <!-- codecov coverage integration with JaCoCo -->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-          <check/>
-        </configuration>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <!-- build a single executable JAR -->
       <plugin>


### PR DESCRIPTION
## Summary
Move to JaCoCo for code coverage since Cobertura instrumentation can't pass SpotBugs checks.
