### PR TITLE
Add JDK 16 to CI and remove intermediate versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [1.8, 9, 10, 11, 12, 13]
+        java_version: [1.8, 11, 16]
         os: [windows-latest, macOS-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
## Summary
Add JDK 16 to CI and remove intermediate versions